### PR TITLE
refactor buffer handling for DB puts

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -8,6 +8,16 @@ exports.sizes = {
   totalsize: 4
 };
 
+/**
+ * [crc][timestamp][keysz][valuesz]
+ */
+exports.headerOffsets = {
+  crc: 0,
+  timestamp: 4,
+  keysize: 12,
+  valsize: 14
+}
+
 exports.writeCheck = {
   fresh: 1,
   wrap: 2,


### PR DESCRIPTION
This commit fixes #5 
- improves write-ops/sec
- improves memory usage when inserting large values
