### PR TITLE
make module.export both export factory & class

### DIFF
--- a/medea.js
+++ b/medea.js
@@ -29,6 +29,9 @@ var writeCheck = constants.writeCheck;
 };*/
 
 var Medea = function(options) {
+  if (!(this instanceof Medea))
+    return new Medea(options);
+
   this.active = null;
   this.keydir = {};
 
@@ -636,6 +639,4 @@ Medea.prototype.compact = function(cb) {
   this.compactor.compact(cb);
 };
 
-module.exports = function(options) {
-  return new Medea(options);
-};
+module.exports = Medea;

--- a/test/medea_test.js
+++ b/test/medea_test.js
@@ -19,6 +19,16 @@ describe('Medea', function() {
     assert(db.maxFileSize > 0);
   });
 
+  describe('initialize', function () {
+    it('can be created as a factory', function () {
+      assert(medea() instanceof medea);
+    });
+
+    it('successfully created as a Class', function () {
+      assert((new medea()) instanceof medea);
+    })
+  });
+
   describe('#put', function() {
     it('successfully stores a String value', function(done) {
       db.put('hello', 'world', function(err) {


### PR DESCRIPTION
Hey, I really like the change in  https://github.com/argo/medea/commit/935670c46e1c4cace527b2a4b19957268e553ab6, but at the same time i can see reasons not to limit it so that the base class isn't available (if for example someone would like to extend the base class).

This change makes both of the initilizing patterns avaialble, from the same exported method.
