### PR TITLE
Emit events for open, close, put, remove, write, and compact.

### DIFF
--- a/medea.js
+++ b/medea.js
@@ -386,7 +386,7 @@ Medea.prototype.write = function(batch, options, cb) {
   var file = this._getActiveFile(bytesToBeWritten);
   var that = this;
 
-  var lineBuffer = Buffer.concat(batchBuffers, batch.size);
+  var lineBuffer = Buffer.concat(batchBuffers, batchSize);
 
   file.write(lineBuffer, { sync: options.sync }, function(err) {
     if (err) {
@@ -468,7 +468,7 @@ Medea.prototype.write = function(batch, options, cb) {
         }
       })
 
-      that.emit('write', batch);
+      that.emit('write', batch, batchSize);
       if (cb) cb();
     });
   });
@@ -581,7 +581,6 @@ Medea.prototype.sync = function(file, cb) {
     }
 
     fs.fsync(file.hintFd, cb);
-    that.emit('sync');
   });
 };
 
@@ -592,7 +591,9 @@ Medea.prototype.compact = function(callback) {
       that.emit('compact');
     }
 
-    callback(err);
+    if (callback) {
+      callback(err);
+    }
   };
 
   this.compactor.compact(cb);

--- a/test/medea_test.js
+++ b/test/medea_test.js
@@ -172,8 +172,9 @@ describe('Medea', function() {
       batch.put('hello2', 'world2');
       batch.remove('hello');
 
-      db.once('write', function(batch1) {
+      db.once('write', function(batch1, size) {
         assert.deepEqual(batch1, batch);
+        assert(size > 0);
         done();
       });
 
@@ -231,6 +232,17 @@ describe('Medea', function() {
           assert(!err);
           done();
         });
+      });
+    });
+
+    it('emits a compact event', function(done) {
+      db.once('compact', function() {
+        assert(true);
+        done();
+      });
+
+      db.put('beep', 'boop', function(err) {
+        db.compact();
       });
     });
   });


### PR DESCRIPTION
This change allows apps to add trigger-like functionality around Medea.
