### PR TITLE
Crash recovery handles cases where hint file is missing but data file is present

### DIFF
--- a/hint_file_parser.js
+++ b/hint_file_parser.js
@@ -1,27 +1,53 @@
 var fs = require('fs');
 var async = require('async');
+var DataFileParser = require('./data_file_parser');
 var constants = require('./constants');
 var KeyDirEntry = require('./keydir_entry');
 var sizes = constants.sizes;
 
 exports.parse = function(dirname, arr, keydir, cb) {
-  var hintFiles = arr.map(function(f) {
-    return f.replace('.medea.data', '.medea.hint');
-  });
-
   async.forEach(
-    hintFiles,
-    function (hintFile, done) {
-      iterator(dirname, keydir, hintFile, done);
+    arr,
+    function (dataFile, done) {
+      iterator(dirname, keydir, dataFile, done);
     },
     cb
   );
 };
 
-var iterator = function(dirname, keydir, hintFile, cb1) {
+// parse data file for keys when hint file is missing
+var datafileIterator = function(dirname, keydir, dataFile, cb1) {
+  var fileId = Number(dataFile.replace(dirname + '/', '').replace('.medea.data', ''));
+  var file = new DataFileParser({ filename: dataFile });
+  file.on('error', cb1);
+  file.on('entry', function(entry) {
+    var key = entry.key.toString();
+    if (!keydir[key] || (keydir[key] && keydir[key].fileId === fileId)) {
+      var kEntry = new KeyDirEntry();
+      kEntry.key = key;
+      kEntry.fileId = fileId;
+      kEntry.timestamp = entry.timestamp;
+      kEntry.valueSize = entry.valueSize;
+      kEntry.valuePosition = entry.valuePosition;
+      keydir[key] = kEntry;
+    }
+  });
+  file.on('end', cb1);
+  file.parse();
+};
+
+var iterator = function(dirname, keydir, dataFile, cb1) {
+  var hintFile = dataFile.replace('.medea.data', '.medea.hint');
   var hintHeaderSize = sizes.timestamp + sizes.keysize + sizes.totalsize + sizes.offset;
 
   var stream = fs.createReadStream(hintFile);
+  stream.on('error', function(err) {
+    // handle hint file missing
+    if (err.code === 'ENOENT') {
+      return datafileIterator(dirname, keydir, dataFile, cb1);
+    }
+    throw err;
+  });
 
   var waiting = new Buffer(0);
   var curlen = 0;

--- a/test/medea_test.js
+++ b/test/medea_test.js
@@ -382,3 +382,34 @@ describe('Medea#open on already opened directory', function () {
     db.close(done);
   });
 });
+
+describe('Medea#open() when there are missing hint files', function () {
+
+  it('should pass', function (done) {
+    var db1 = medea({});
+    require('rimraf')(directory, function() {
+      db1.open(directory, function(err) {
+        assert(!err);
+        db1.put('hello', 'world', function(err) {
+          assert(!err);
+          db1.close(function(err) {
+            assert(!err);
+            fs.unlink(directory + '/1.medea.hint', function() {
+              var db2 = medea({});
+              db2.open(directory, function(err) {
+                assert(!err);
+                // error is thrown before executing this callback
+                db2.get('hello', function(err, val) {
+                  assert(!err);
+                  assert.equal(val.toString(), 'world');
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
@kevinswiber  Here is a possible solution to handle cases where hint file is missing. #47  `hint_file_parser` derives the keys from the data file if its hint file is missing, uses the `data_file_parser`. I had to modify the `data_file_parser` to also return `valuePosition` on the entry.
