### PR TITLE
Path issue in hint_file_parser

### DIFF
--- a/hint_file_parser.js
+++ b/hint_file_parser.js
@@ -18,7 +18,7 @@ exports.parse = function(dirname, arr, keydir, cb) {
 
 // parse data file for keys when hint file is missing
 var datafileIterator = function(dirname, keydir, dataFile, cb1) {
-  var fileId = Number(dataFile.replace(dirname + '/', '').replace('.medea.data', ''));
+  var fileId = Number(path.basename(dataFile, '.medea.data'));
   var file = new DataFileParser({ filename: dataFile });
   file.on('error', cb1);
   file.on('entry', function(entry) {

--- a/test/medea_test.js
+++ b/test/medea_test.js
@@ -412,4 +412,33 @@ describe('Medea#open() when there are missing hint files', function () {
     });
   });
 
+  it('should pass with leading ./ in directory name', function (done) {
+    var directory = './test/tmp/medea_test';
+    var db1 = medea({});
+    require('rimraf')(directory, function() {
+      db1.open(directory, function(err) {
+        assert(!err);
+        db1.put('hello', 'world', function(err) {
+          assert(!err);
+          db1.close(function(err) {
+            assert(!err);
+            fs.unlink(directory + '/1.medea.hint', function() {
+              var db2 = medea({});
+              db2.open(directory, function(err) {
+                assert(!err);
+                // error is thrown before executing this callback
+                db2.get('hello', function(err, val) {
+                  assert(!err);
+                  assert.equal(val.toString(), 'world');
+                  done();
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+
+
 });


### PR DESCRIPTION
`db` works when hint files are missing but, `./db` does not.