### PR TITLE
use map instead of object for keydir

### DIFF
--- a/hint_file_parser.js
+++ b/hint_file_parser.js
@@ -23,14 +23,14 @@ var datafileIterator = function(dirname, keydir, dataFile, cb1) {
   file.on('error', cb1);
   file.on('entry', function(entry) {
     var key = entry.key.toString();
-    if (!keydir[key] || (keydir[key] && keydir[key].fileId === fileId)) {
+    if (!keydir.has(key) || (keydir.has(key) && keydir.get(key).fileId === fileId)) {
       var kEntry = new KeyDirEntry();
       kEntry.key = key;
       kEntry.fileId = fileId;
       kEntry.timestamp = entry.timestamp;
       kEntry.valueSize = entry.valueSize;
       kEntry.valuePosition = entry.valuePosition;
-      keydir[key] = kEntry;
+      keydir.set(key, kEntry);
     }
   });
   file.on('end', cb1);
@@ -114,7 +114,7 @@ var iterator = function(dirname, keydir, dataFile, cb1) {
         var key = keyBuf.toString();
 
         var fileId = Number(hintFile.replace(dirname + path.sep, '').replace('.medea.hint', ''));
-        if (!keydir[key] || (keydir[key] && keydir[key].fileId === fileId)) {
+        if (!keydir.has(key) || (keydir.has(key) && keydir.get(key).fileId === fileId)) {
           var entry = new KeyDirEntry();
           entry.key = key;
           entry.fileId = fileId;
@@ -122,7 +122,7 @@ var iterator = function(dirname, keydir, dataFile, cb1) {
           entry.valueSize = lastHeaderBuf.readUInt32BE(sizes.timestamp + sizes.keysize) - key.length - sizes.header;
           entry.valuePosition = lastHeaderBuf.readDoubleBE(sizes.timestamp + sizes.keysize + sizes.totalsize) + sizes.header + key.length;
 
-          keydir[key] = entry;
+          keydir.set(key, entry);
         }
 
         chunk = chunk.slice(lastKeyLen);

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "async": "^0.9.0",
     "buffer-crc32": "~0.2.1",
     "buffer-equal": "0.0.1",
+    "es6-map": "^0.1.1",
     "mkdirp": "^0.5.0",
     "monotonic-timestamp": "0.0.8",
     "pidlockfile": "^1.1.1",

--- a/snapshot.js
+++ b/snapshot.js
@@ -1,15 +1,18 @@
+var Map = global.Map || require('es6-map');
+
+
 var Snapshot = module.exports = function (db) {
   var that = this;
 
-  this.keydir = {};
+  this.keydir = new Map();
   this.closed = false;
   this.fileIds = [];
   this.db = db
 
-  Object.keys(db.keydir).forEach(function (key) {
-    that.keydir[key] = db.keydir[key];
-    if (that.fileIds.indexOf(db.keydir[key].fileId) === -1)
-        that.fileIds.push(db.keydir[key].fileId)
+  db.keydir.forEach(function (value, key) {
+    that.keydir.set(key, db.keydir.get(key));
+    if (that.fileIds.indexOf(db.keydir.get(key).fileId) === -1)
+        that.fileIds.push(db.keydir.get(key).fileId)
   });
   this.fileIds.forEach(function (fileId) {
     db.fileReferences[fileId] = (db.fileReferences[fileId] || 0) + 1;

--- a/test/hint_file_parser_test.js
+++ b/test/hint_file_parser_test.js
@@ -4,14 +4,15 @@ var crc32 = require('buffer-crc32');
 var DataFile = require('../data_file');
 var HintFileParser = require('../hint_file_parser');
 var KeyDirEntry = require('../keydir_entry');
-
+var Map = global.Map || require('es6-map');
+var utils = require('../utils')
 var sizes = constants.sizes;
 var headerOffsets = constants.headerOffsets;
 
 var directory = __dirname + '/tmp/hint_file_parser_test';
 var arr = [];
 var files = [];
-var keydir = {};
+var keydir = new Map();
 
 function createBuffer(k, v) {
   var ts = Date.now();
@@ -105,17 +106,17 @@ describe('HintFileParser', function() {
 
     it('parses hint file entries', function(done) {
       HintFileParser.parse(directory, arr, keydir, function(err) {
-        assert(!!Object.keys(keydir).length);
+        assert(!!utils.dumpMapKeys(keydir).length);
         for(var i = 0; i < 10; ++i) {
-          assert.equal(keydir['hello' + i].key, 'hello' + i)
-          assert.equal(keydir['hello' + i].valueSize, 500)
+          assert.equal(keydir.get('hello' + i).key, 'hello' + i)
+          assert.equal(keydir.get('hello' + i).valueSize, 500)
         }
         done();
       });
     });
 
     it('fires the callback even with an empty file array', function(done) {
-      HintFileParser.parse(directory, [], {}, function(err) {
+      HintFileParser.parse(directory, [], new Map(), function(err) {
         assert(!err);
         done();
       });

--- a/test/medea_test.js
+++ b/test/medea_test.js
@@ -73,6 +73,24 @@ describe('Medea', function() {
         });
       });
     });
+    it('unsuccessfully retrieves a value', function(done) {
+      db.put('foo', new Buffer('bar'), function(err) {
+        db.get('bar', function(err, val) {
+          assert(!err);
+          assert(!val);
+          done();
+        });
+      });
+    });
+    it('unsuccessfully retrieves a value reserved key name', function(done) {
+      db.put('foo', new Buffer('bar'), function(err) {
+        db.get('constructor', function(err, val) {
+          assert(!err);
+          assert(!val);
+          done();
+        });
+      });
+    });
   });
 
   describe('#remove', function() {
@@ -277,7 +295,7 @@ describe('Medea', function() {
     }
 
     put(0);
-    
+
   });
 
   it('successfully concurrently writes large amounts of data', function(done) {

--- a/utils.js
+++ b/utils.js
@@ -5,3 +5,12 @@ var constants = require('./constants');
 exports.isTombstone = function (buffer) {
   return bufferEqual(buffer, constants.tombstone);
 }
+
+exports.dumpMapKeys = function (map) {
+  var out = new Array(map.size);
+  var i = 0;
+  map.forEach(function (value, key) {
+    out[i++] = key;
+  });
+  return out;
+}


### PR DESCRIPTION
currently if you try to get a key like 'prototype' or 'constructor' it will incorrectly find one due to the fact an object is being used as a hash, this switches to use an es6 map (and adds a shim for older versions of node).  This should in theory be faster as well.  Includes a test that fails without this patch.