### PR TITLE
Windows fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ A persistent key-value storage library.
 * Supports atomic batch writes.
 * Allows snapshots for consistent views of data.
 
-[![Build Status](https://api.travis-ci.org/medea/medea.svg?branch=master)](https://travis-ci.org/medea/medea)
+[![Build Status](https://api.travis-ci.org/medea/medea.svg?branch=master)](https://travis-ci.org/medea/medea)  [![Build status](https://ci.appveyor.com/api/projects/status/cim1lbhjdxn33mfh/branch/master?svg=true)](https://ci.appveyor.com/project/kevinswiber/medea/branch/master)
+
 
 ## Contents
 

--- a/destroy.js
+++ b/destroy.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var path = require('path');
+var rimraf = require('rimraf');
 
 var async = require('async');
 var lockFile = require('pidlockfile');
@@ -27,14 +28,8 @@ var destroy = function (directory, cb) {
           return path.join(directory, fileName);
         })
 
-      async.forEach(files, fs.unlink, function (err) {
-        if (err) {
-          return cb(err);
-        }
-
-        fs.rmdir(directory, function (err) {
-          cb(err && err.code !== 'ENOTEMPTY' ? err : undefined);
-        });
+      rimraf(directory, function (err) {
+        cb(err && err.code !== 'ENOTEMPTY' ? err : undefined);
       });
     });
   });

--- a/destroy.js
+++ b/destroy.js
@@ -28,8 +28,14 @@ var destroy = function (directory, cb) {
           return path.join(directory, fileName);
         })
 
-      rimraf(directory, function (err) {
-        cb(err && err.code !== 'ENOTEMPTY' ? err : undefined);
+      async.forEach(files, rimraf, function (err) {
+        if (err) {
+          return cb(err);
+        }
+
+        fs.rmdir(directory, function (err) {
+          cb(err && err.code !== 'ENOTEMPTY' ? err : undefined);
+        });
       });
     });
   });

--- a/medea.js
+++ b/medea.js
@@ -195,7 +195,7 @@ Medea.prototype._validateFiles = function (cb) {
           rimraf(file, function(err) {
             count++;
             if (files.length === count) {
-	            if (err.code === 'EPERM' && process.platform === 'win32') {
+	            if (err && err.code === 'EPERM' && process.platform === 'win32') {
 	              cb(null, validFiles);
 	            } else {
                 cb(err,validFiles);

--- a/test/medea_destroy_test.js
+++ b/test/medea_destroy_test.js
@@ -71,8 +71,10 @@ describe('Medea.destroy', function() {
 
     it('deletes the folder', function (done) {
       medea.destroy(directory, function () {
-        assert.equal(fs.existsSync(directory), false);
-        done();
+        fs.stat(directory, function(err, stat) {
+          assert(!err);
+          done();
+        });
       });
     });
   });
@@ -94,18 +96,19 @@ describe('Medea.destroy', function() {
 });
 
 describe('Medea#destroy', function () {
-  var db;
-
   describe('initialized and closed db', function () {
     it('deletes the folder', function (done) {
+      var db;
       rimraf(directory, function () {
         db = medea();
         db.open(directory, function () {
           db.put('beep', 'boop', function () {
             db.close(function() {
               db.destroy(function () {
-                assert.equal(fs.existsSync(directory), false);
-                done();
+                fs.stat(directory, function(err, stat) {
+                  assert(!err);
+                  done();
+                });
               });
             });
           });

--- a/test/medea_destroy_test.js
+++ b/test/medea_destroy_test.js
@@ -1,5 +1,6 @@
 var assert = require('assert');
 var fs = require('fs');
+var path = require('path');
 
 var rimraf = require('rimraf');
 
@@ -70,10 +71,21 @@ describe('Medea.destroy', function() {
     });
 
     it('deletes the folder', function (done) {
-      medea.destroy(directory, function () {
-        fs.stat(directory, function(err, stat) {
-          assert(!err);
-          done();
+      var dir = directory + 'deletes_folder';
+      rimraf(dir, function () {
+        var db = medea();
+        db.open(dir, function() {
+          db.put('beep', 'boop', function () {
+            db.close(function() {
+              fs.writeFileSync(path.join(directory, 'medea.lock'), '123')
+              medea.destroy(dir, function (err) {
+                fs.stat(dir, function(err, stat) {
+                  assert(err);
+                  done();
+                });
+              });
+            });
+          });
         });
       });
     });
@@ -99,14 +111,15 @@ describe('Medea#destroy', function () {
   describe('initialized and closed db', function () {
     it('deletes the folder', function (done) {
       var db;
-      rimraf(directory, function () {
+      var dir = directory + 'initialize_and_close';
+      rimraf(dir, function () {
         db = medea();
-        db.open(directory, function () {
+        db.open(dir, function () {
           db.put('beep', 'boop', function () {
             db.close(function() {
               db.destroy(function () {
-                fs.stat(directory, function(err, stat) {
-                  assert(!err);
+                fs.stat(dir, function(err, stat) {
+                  assert(err);
                   done();
                 });
               });

--- a/test/medea_test.js
+++ b/test/medea_test.js
@@ -387,13 +387,14 @@ describe('Medea', function() {
 
 describe('Medea#open() when there are empty hint & data-files', function () {
   var db;
+  directory += 'empty_hint_data_files';
   before(function (done) {
     require('rimraf')(directory, function () {
       fs.mkdir(directory, function () {
-        fs.open(path.join(directory, '4.medea.data'), 'w', function (err, fd) {
+        fs.open(path.join(directory, '999.medea.data'), 'w', function (err, fd) {
           assert(!err);
           fs.close(fd, function () {
-            fs.open(path.join(directory, '4.medea.hint'), 'w', function (err, fd ) {
+            fs.open(path.join(directory, '999.medea.hint'), 'w', function (err, fd ) {
               assert(!err);
               fs.close(fd, function () {
                 db = medea({});
@@ -408,8 +409,8 @@ describe('Medea#open() when there are empty hint & data-files', function () {
 
   it('successfully remove the empty files', function (done) {
     fs.readdir(directory, function (err, files) {
-      assert.deepEqual(files.indexOf('4.medea.data'), -1)
-      assert.deepEqual(files.indexOf('4.medea.hint'), -1)
+      assert.deepEqual(files.indexOf('999.medea.data'), -1)
+      assert.deepEqual(files.indexOf('999.medea.hint'), -1)
       done()
     });
   });

--- a/test/medea_test.js
+++ b/test/medea_test.js
@@ -386,12 +386,15 @@ describe('Medea', function() {
 });
 
 describe('Medea#open() when there are empty hint & data-files', function () {
+  var db;
   before(function (done) {
     require('rimraf')(directory, function () {
       fs.mkdir(directory, function () {
-        fs.open(directory + '/4.medea.data', 'w', function (err, fd) {
+        fs.open(path.join(directory, '4.medea.data'), 'w', function (err, fd) {
+          assert(!err);
           fs.close(fd, function () {
-            fs.open(directory + '/4.medea.hint', 'w', function (err, fd ) {
+            fs.open(path.join(directory, '4.medea.hint'), 'w', function (err, fd ) {
+              assert(!err);
               fs.close(fd, function () {
                 db = medea({});
                 db.open(directory, done);


### PR DESCRIPTION
This fixes #61 and various other Windows issues.  We were having tons of issues with `fs.unlink`.  Windows can be a little finicky.  I replaced `fs.unlink` with `rimraf`, which supports retrying on Windows issues.

I also added the AppVeyor badge, which shows continuous integration status with Windows.  It currently points to the master branch, so while it may look broken on first-glance, taking a look at the windows_fixes branch will show that tests are passing for Node versions 0.10.x, 0.12.x, 4.0.x, 4.1.x, and 5.0.x on both x86 and x64.